### PR TITLE
Added jsx-no-lambda converter

### DIFF
--- a/src/rules/converters/eslint-plugin-react/jsx-no-lambda.ts
+++ b/src/rules/converters/eslint-plugin-react/jsx-no-lambda.ts
@@ -1,0 +1,12 @@
+import { RuleConverter } from "../../converter";
+
+export const convertJsxNoLambda: RuleConverter = () => {
+    return {
+        rules: [
+            {
+                ruleName: "react/jsx-no-lambda",
+            },
+        ],
+        plugins: ["eslint-plugin-react"],
+    };
+};

--- a/src/rules/converters/eslint-plugin-react/tests/jsx-no-lambda.tests.ts
+++ b/src/rules/converters/eslint-plugin-react/tests/jsx-no-lambda.tests.ts
@@ -1,0 +1,18 @@
+import { convertJsxNoLambda } from "../jsx-no-lambda";
+
+describe(convertJsxNoLambda, () => {
+    test("conversion without arguments", () => {
+        const result = convertJsxNoLambda({
+            ruleArguments: [],
+        });
+
+        expect(result).toEqual({
+            rules: [
+                {
+                    ruleName: "react/jsx-no-lambda",
+                },
+            ],
+            plugins: ["eslint-plugin-react"],
+        });
+    });
+});

--- a/src/rules/rulesConverters.ts
+++ b/src/rules/rulesConverters.ts
@@ -177,6 +177,7 @@ import { convertJsxBooleanValue } from "./converters/eslint-plugin-react/jsx-boo
 import { convertJsxCurlySpacing } from "./converters/eslint-plugin-react/jsx-curly-spacing";
 import { convertJsxEqualsSpacing } from "./converters/eslint-plugin-react/jsx-equals-spacing";
 import { convertJsxKey } from "./converters/eslint-plugin-react/jsx-key";
+import { convertJsxNoLambda } from "./converters/eslint-plugin-react/jsx-no-lambda";
 
 /**
  * Keys TSLint rule names to their ESLint rule converters.
@@ -218,6 +219,7 @@ export const rulesConverters = new Map([
     ["jsx-curly-spacing", convertJsxCurlySpacing],
     ["jsx-equals-spacing", convertJsxEqualsSpacing],
     ["jsx-key", convertJsxKey],
+    ["jsx-no-lambda", convertJsxNoLambda],
     ["label-position", convertLabelPosition],
     ["linebreak-style", convertLinebreakStyle],
     ["max-classes-per-file", convertMaxClassesPerFile],


### PR DESCRIPTION
<!--
👋 Hi, thanks for sending a PR to tslint-to-eslint-config! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.
-->

## PR Checklist

-   [x] Addresses an existing issue: fixes #523
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/typescript-eslint/tslint-to-eslint-config/labels/status%3A%20accepting%20prs)

## Overview

<!-- Brief description of what is changed and how the code change does that. -->
Based on [eslint-plugin-react](https://github.com/palantir/tslint-react#rules), provides the correct converter for this rule.
